### PR TITLE
Add error reporting severity/level in exception data container

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -600,6 +600,12 @@ class Raven_Client
                 ),
             );
 
+            if (empty($exc_data['severity'])) {
+                if (method_exists($exc, 'getSeverity')) {
+                    $exc_data['severity'] = $exc->getSeverity();
+                }
+            }
+
             $exceptions[] = $exc_data;
         } while ($has_chained_exceptions && $exc = $exc->getPrevious());
 


### PR DESCRIPTION
Sentry has not a method to skip errors based on error_reporting level
Useful for select which events must be sent, into `Raven_Client::setSendCallback`