### PR TITLE
Fixup travis for php5.3 precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
+sudo: false
+
+env:
+  - REMOVE_XDEBUG="0"
+  - REMOVE_XDEBUG="1"
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -17,6 +21,12 @@ matrix:
     - php: nightly
   fast_finish: true
   include:
+    - php: 5.3
+      env: REMOVE_XDEBUG="0"
+      dist: precise
+    - php: 5.3
+      env: REMOVE_XDEBUG="1"
+      dist: precise
     - php: 7.0
       env: REMOVE_XDEBUG="0" DISABLE_ASSERTIONS="1"
     - php: 7.0
@@ -37,12 +47,6 @@ matrix:
       env: REMOVE_XDEBUG="1"
     - php: nightly
       env: REMOVE_XDEBUG="1"
-
-env:
-  - REMOVE_XDEBUG="0"
-  - REMOVE_XDEBUG="1"
-
-sudo: false
 
 cache:
   directories:


### PR DESCRIPTION
Fix for travis-ci for the php 5.3 version.

```
PHP 5.3 is supported only on Precise.
See https://docs.travis-ci.com/user/reference/trusty#PHP-images on how to test PHP 5.3 on Precise.
```