### PR TITLE
Remove tests for php7.0 in travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
-  - 7.1
-  - nightly
-  - hhvm-3.12
 
 matrix:
-  allow_failures:
-    - php: 7.1
-    - php: hhvm-3.12
-    - php: nightly
   fast_finish: true
   include:
     - php: 5.3
@@ -27,26 +19,6 @@ matrix:
     - php: 5.3
       env: REMOVE_XDEBUG="1"
       dist: precise
-    - php: 7.0
-      env: REMOVE_XDEBUG="0" DISABLE_ASSERTIONS="1"
-    - php: 7.0
-      env: REMOVE_XDEBUG="1" DISABLE_ASSERTIONS="1"
-    - php: 7.1
-      env: REMOVE_XDEBUG="0" DISABLE_ASSERTIONS="1"
-    - php: 7.1
-      env: REMOVE_XDEBUG="1" DISABLE_ASSERTIONS="1"
-    - php: nightly
-      env: REMOVE_XDEBUG="0" DISABLE_ASSERTIONS="1"
-    - php: hhvm-3.12
-      env: REMOVE_XDEBUG="0" HHVM="1"
-      dist: trusty
-  exclude:
-    - php: hhvm-3.12
-      env: REMOVE_XDEBUG="0"
-    - php: hhvm-3.12
-      env: REMOVE_XDEBUG="1"
-    - php: nightly
-      env: REMOVE_XDEBUG="1"
 
 cache:
   directories:


### PR DESCRIPTION
This repo is a fork of the official library designed to work on php5.2. 
I believe it makes no sense to spend efforts to make it work on php7.
If you want it to work with php >= 7 use the [official library](https://github.com/getsentry/sentry-php).